### PR TITLE
Resultado de votação agrupado por palavra

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -2,7 +2,10 @@ class VotesController < ApplicationController
   CHOICES = Integer(ENV['OPTIONS'] || 9)
 
   def index
-    @words = Vote.order(:word, :color).group(:word, :color, :total).group_by(&:word)
+    @words = Vote.select(:word, :color, :total)
+      .order(:word, :color)
+      .group(:word, :color, :total)
+      .group_by(&:word)
   end
 
   def new


### PR DESCRIPTION
Quando usamos `group` em SQL é importante dizer quais os campos que queremos que a query retorne, evitando problemas do bd querer agrupar colunas desnecessárias (`id` nesse caso).

pls look @rmasoni 